### PR TITLE
feat: add real estate tab with CRUD [superseded by #11]

### DIFF
--- a/src/app/main-component/main-component.component.html
+++ b/src/app/main-component/main-component.component.html
@@ -18,4 +18,11 @@
       <broker-worth-graph [graphPoints]="brokerGraph"></broker-worth-graph>
     </ng-template>
   </mat-tab>
+
+  <!-- Real Estate tab -->
+  <mat-tab label="Immobili">
+    <ng-template matTabContent>
+      <app-real-estate></app-real-estate>
+    </ng-template>
+  </mat-tab>
 </mat-tab-group>

--- a/src/app/main-component/main-component.component.ts
+++ b/src/app/main-component/main-component.component.ts
@@ -8,6 +8,7 @@ import {GraphPointsDto} from "../../models/graph-points.dto";
 import {MatTableModule} from "@angular/material/table";
 import {MatTab, MatTabContent, MatTabGroup} from "@angular/material/tabs";
 import {LineGraph2Component} from "../broker-worth-graph/broker-worth-graph.component";
+import {RealEstateComponent} from "../real-estate/real-estate.component";
 
 @Component({
   selector: 'app-main-component',
@@ -21,7 +22,8 @@ import {LineGraph2Component} from "../broker-worth-graph/broker-worth-graph.comp
     MatTab,
     MatTabGroup,
     LineGraph2Component,
-    MatTabContent
+    MatTabContent,
+    RealEstateComponent
   ],
   templateUrl: './main-component.component.html',
   styleUrl: './main-component.component.css'

--- a/src/app/real-estate/real-estate.component.css
+++ b/src/app/real-estate/real-estate.component.css
@@ -1,0 +1,39 @@
+.re-container {
+  padding: 16px;
+}
+
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+table {
+  width: 100%;
+}
+
+.empty {
+  text-align: center;
+  padding: 32px;
+  color: #888;
+}
+
+.form-panel {
+  margin-top: 24px;
+  padding: 24px;
+  border-radius: 4px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 16px;
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+  justify-content: flex-end;
+}

--- a/src/app/real-estate/real-estate.component.html
+++ b/src/app/real-estate/real-estate.component.html
@@ -1,0 +1,72 @@
+<div class="re-container">
+  <div class="header-row">
+    <h3>Immobili — Valore totale: {{ totalWorth | number:'1.2-2' }} €</h3>
+    <button mat-raised-button color="primary" (click)="openCreate()">+ Aggiungi</button>
+  </div>
+
+  <table mat-table [dataSource]="properties" class="mat-elevation-z2">
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef>Nome</th>
+      <td mat-cell *matCellDef="let p">{{ p.name }}</td>
+    </ng-container>
+    <ng-container matColumnDef="address">
+      <th mat-header-cell *matHeaderCellDef>Indirizzo</th>
+      <td mat-cell *matCellDef="let p">{{ p.address }}</td>
+    </ng-container>
+    <ng-container matColumnDef="purchaseDate">
+      <th mat-header-cell *matHeaderCellDef>Data acquisto</th>
+      <td mat-cell *matCellDef="let p">{{ p.purchaseDate }}</td>
+    </ng-container>
+    <ng-container matColumnDef="purchasePrice">
+      <th mat-header-cell *matHeaderCellDef>Prezzo acquisto</th>
+      <td mat-cell *matCellDef="let p">{{ p.purchasePrice | number:'1.2-2' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="currentEstimatedValue">
+      <th mat-header-cell *matHeaderCellDef>Valore stimato</th>
+      <td mat-cell *matCellDef="let p">{{ p.currentEstimatedValue | number:'1.2-2' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="monthlyRent">
+      <th mat-header-cell *matHeaderCellDef>Affitto/mese</th>
+      <td mat-cell *matCellDef="let p">{{ p.monthlyRent | number:'1.2-2' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="monthlyExpenses">
+      <th mat-header-cell *matHeaderCellDef>Spese/mese</th>
+      <td mat-cell *matCellDef="let p">{{ p.monthlyExpenses | number:'1.2-2' }}</td>
+    </ng-container>
+    <ng-container matColumnDef="currency">
+      <th mat-header-cell *matHeaderCellDef>Valuta</th>
+      <td mat-cell *matCellDef="let p">{{ p.currency }}</td>
+    </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let p">
+        <button mat-icon-button (click)="openEdit(p)" title="Modifica">✏️</button>
+        <button mat-icon-button (click)="delete(p.id)" title="Elimina">🗑️</button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+
+  <div *ngIf="properties.length === 0" class="empty">Nessun immobile registrato.</div>
+
+  <!-- Form add/edit -->
+  <div *ngIf="showForm" class="form-panel mat-elevation-z4">
+    <h4>{{ editingId ? 'Modifica immobile' : 'Nuovo immobile' }}</h4>
+    <div class="form-grid">
+      <mat-form-field><mat-label>Nome</mat-label><input matInput [(ngModel)]="form.name"/></mat-form-field>
+      <mat-form-field><mat-label>Indirizzo</mat-label><input matInput [(ngModel)]="form.address"/></mat-form-field>
+      <mat-form-field><mat-label>Data acquisto (yyyy-MM-dd)</mat-label><input matInput [(ngModel)]="form.purchaseDate"/></mat-form-field>
+      <mat-form-field><mat-label>Prezzo acquisto</mat-label><input matInput type="number" [(ngModel)]="form.purchasePrice"/></mat-form-field>
+      <mat-form-field><mat-label>Valore stimato attuale</mat-label><input matInput type="number" [(ngModel)]="form.currentEstimatedValue"/></mat-form-field>
+      <mat-form-field><mat-label>Affitto mensile</mat-label><input matInput type="number" [(ngModel)]="form.monthlyRent"/></mat-form-field>
+      <mat-form-field><mat-label>Spese mensili</mat-label><input matInput type="number" [(ngModel)]="form.monthlyExpenses"/></mat-form-field>
+      <mat-form-field><mat-label>Valuta</mat-label><input matInput [(ngModel)]="form.currency"/></mat-form-field>
+    </div>
+    <div class="form-actions">
+      <button mat-button (click)="cancel()">Annulla</button>
+      <button mat-raised-button color="primary" (click)="save()">Salva</button>
+    </div>
+  </div>
+</div>

--- a/src/app/real-estate/real-estate.component.ts
+++ b/src/app/real-estate/real-estate.component.ts
@@ -1,0 +1,87 @@
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {HttpClient} from '@angular/common/http';
+import {MatTableModule} from '@angular/material/table';
+import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatIconModule} from '@angular/material/icon';
+import {RealEstateDto} from '../../models/real-estate.dto';
+
+const API = 'http://localhost:8080/api/realestate';
+
+@Component({
+  selector: 'app-real-estate',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatTableModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule
+  ],
+  templateUrl: './real-estate.component.html',
+  styleUrl: './real-estate.component.css'
+})
+export class RealEstateComponent implements OnInit {
+  properties: RealEstateDto[] = [];
+  totalWorth: number = 0;
+  displayedColumns = ['name', 'address', 'purchaseDate', 'purchasePrice', 'currentEstimatedValue', 'monthlyRent', 'monthlyExpenses', 'currency', 'actions'];
+
+  showForm = false;
+  editingId: number | null = null;
+  form: RealEstateDto = this.emptyForm();
+
+  constructor(private http: HttpClient) {}
+
+  ngOnInit() {
+    this.load();
+  }
+
+  load() {
+    this.http.get<RealEstateDto[]>(API).subscribe(data => this.properties = data);
+    this.http.get<number>(`${API}/worth`).subscribe(w => this.totalWorth = w);
+  }
+
+  openCreate() {
+    this.editingId = null;
+    this.form = this.emptyForm();
+    this.showForm = true;
+  }
+
+  openEdit(p: RealEstateDto) {
+    this.editingId = p.id ?? null;
+    this.form = {...p};
+    this.showForm = true;
+  }
+
+  save() {
+    if (this.editingId != null) {
+      this.http.put<RealEstateDto>(`${API}/${this.editingId}`, this.form).subscribe(() => {
+        this.showForm = false;
+        this.load();
+      });
+    } else {
+      this.http.post<RealEstateDto>(API, this.form).subscribe(() => {
+        this.showForm = false;
+        this.load();
+      });
+    }
+  }
+
+  delete(id: number | undefined) {
+    if (id == null) return;
+    this.http.delete(`${API}/${id}`).subscribe(() => this.load());
+  }
+
+  cancel() {
+    this.showForm = false;
+  }
+
+  private emptyForm(): RealEstateDto {
+    return {name: '', address: '', purchaseDate: '', purchasePrice: 0, currentEstimatedValue: 0, monthlyRent: 0, monthlyExpenses: 0, currency: 'EUR'};
+  }
+}

--- a/src/models/real-estate.dto.ts
+++ b/src/models/real-estate.dto.ts
@@ -1,0 +1,11 @@
+export interface RealEstateDto {
+  id?: number;
+  name: string;
+  address: string;
+  purchaseDate: string;
+  purchasePrice: number;
+  currentEstimatedValue: number;
+  monthlyRent: number;
+  monthlyExpenses: number;
+  currency: string;
+}


### PR DESCRIPTION
## Summary
- Nuovo `RealEstateComponent` con tabella Material e form inline per aggiunta/modifica
- Tutte le operazioni CRUD via API backend
- Valore totale patrimonio immobiliare nell'intestazione
- Nuovo tab 'Immobili' nel MainComponent

## Test plan
- [ ] Aprire tab 'Immobili' → tabella vuota visibile
- [ ] Cliccare '+ Aggiungi' → form visibile
- [ ] Compilare e salvare → immobile appare in lista
- [ ] Cliccare ✏️ → dati pre-compilati, modifica e salva
- [ ] Cliccare 🗑️ → immobile rimosso

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)