### PR TITLE
feat: Monte Carlo tab with interactive projection chart [superseded by #12]

### DIFF
--- a/src/app/main-component/main-component.component.html
+++ b/src/app/main-component/main-component.component.html
@@ -18,4 +18,11 @@
       <broker-worth-graph [graphPoints]="brokerGraph"></broker-worth-graph>
     </ng-template>
   </mat-tab>
+
+  <!-- Monte Carlo tab -->
+  <mat-tab label="Monte Carlo">
+    <ng-template matTabContent>
+      <app-monte-carlo></app-monte-carlo>
+    </ng-template>
+  </mat-tab>
 </mat-tab-group>

--- a/src/app/main-component/main-component.component.ts
+++ b/src/app/main-component/main-component.component.ts
@@ -8,6 +8,7 @@ import {GraphPointsDto} from "../../models/graph-points.dto";
 import {MatTableModule} from "@angular/material/table";
 import {MatTab, MatTabContent, MatTabGroup} from "@angular/material/tabs";
 import {LineGraph2Component} from "../broker-worth-graph/broker-worth-graph.component";
+import {MonteCarloComponent} from "../monte-carlo/monte-carlo.component";
 
 @Component({
   selector: 'app-main-component',
@@ -21,7 +22,8 @@ import {LineGraph2Component} from "../broker-worth-graph/broker-worth-graph.comp
     MatTab,
     MatTabGroup,
     LineGraph2Component,
-    MatTabContent
+    MatTabContent,
+    MonteCarloComponent
   ],
   templateUrl: './main-component.component.html',
   styleUrl: './main-component.component.css'

--- a/src/app/monte-carlo/monte-carlo.component.css
+++ b/src/app/monte-carlo/monte-carlo.component.css
@@ -1,0 +1,21 @@
+.mc-container {
+  padding: 16px;
+}
+
+.controls {
+  display: flex;
+  gap: 16px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.error {
+  color: #f44336;
+}
+
+.legend-note {
+  font-size: 0.85em;
+  color: #555;
+  margin-bottom: 8px;
+}

--- a/src/app/monte-carlo/monte-carlo.component.html
+++ b/src/app/monte-carlo/monte-carlo.component.html
@@ -1,0 +1,29 @@
+<div class="mc-container">
+  <h3>Simulazione Monte Carlo — Proiezione portafoglio</h3>
+
+  <div class="controls">
+    <mat-form-field>
+      <mat-label>Anni di proiezione</mat-label>
+      <input matInput type="number" [(ngModel)]="years" min="1" max="50"/>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Numero simulazioni</mat-label>
+      <input matInput type="number" [(ngModel)]="simulations" min="100" max="50000" step="1000"/>
+    </mat-form-field>
+
+    <button mat-raised-button color="primary" (click)="run()" [disabled]="loading">
+      {{ loading ? 'Elaborazione...' : 'Esegui simulazione' }}
+    </button>
+  </div>
+
+  <p *ngIf="error" class="error">{{ error }}</p>
+
+  <p class="legend-note">
+    <strong>P50</strong> = mediana &nbsp;|&nbsp;
+    <strong>P5–P95</strong> = range di confidenza &nbsp;|&nbsp;
+    Basato sui rendimenti mensili storici del portafoglio
+  </p>
+
+  <canvas id="MonteCarloChart"></canvas>
+</div>

--- a/src/app/monte-carlo/monte-carlo.component.ts
+++ b/src/app/monte-carlo/monte-carlo.component.ts
@@ -1,0 +1,81 @@
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {HttpClient} from '@angular/common/http';
+import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import Chart from 'chart.js/auto';
+import {GraphPointsDto} from '../../models/graph-points.dto';
+
+const API = 'http://localhost:8080/api/montecarlo';
+
+const PERCENTILE_COLORS: { [key: string]: string } = {
+  'P5':  'rgba(244, 67, 54, 0.8)',
+  'P25': 'rgba(255, 152, 0, 0.8)',
+  'P50': 'rgba(33, 150, 243, 1)',
+  'P75': 'rgba(76, 175, 80, 0.8)',
+  'P95': 'rgba(156, 39, 176, 0.8)',
+};
+
+@Component({
+  selector: 'app-monte-carlo',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatButtonModule, MatFormFieldModule, MatInputModule],
+  templateUrl: './monte-carlo.component.html',
+  styleUrl: './monte-carlo.component.css'
+})
+export class MonteCarloComponent {
+  years = 10;
+  simulations = 5000;
+  loading = false;
+  error = '';
+
+  private chart: any;
+
+  constructor(private http: HttpClient) {}
+
+  run() {
+    this.loading = true;
+    this.error = '';
+    this.http.get<GraphPointsDto>(`${API}?years=${this.years}&simulations=${this.simulations}`).subscribe({
+      next: (data) => {
+        this.loading = false;
+        this.renderChart(data);
+      },
+      error: (err) => {
+        this.loading = false;
+        this.error = `Errore: ${err.message}`;
+      }
+    });
+  }
+
+  private renderChart(data: GraphPointsDto) {
+    const labels = data.uniqueLabels as unknown as string[];
+    const datasets = data.uniqueGraphNames.map((name: string) => ({
+      label: name,
+      data: labels.map((l: string) => data.graphData[name]?.[l] ?? null),
+      borderColor: PERCENTILE_COLORS[name] ?? 'rgba(100,100,100,0.8)',
+      backgroundColor: 'transparent',
+      borderWidth: name === 'P50' ? 2.5 : 1.5,
+      pointRadius: 0,
+      tension: 0.3,
+    }));
+
+    if (!this.chart) {
+      this.chart = new Chart('MonteCarloChart', {
+        type: 'line',
+        data: {labels, datasets},
+        options: {
+          aspectRatio: 2.5,
+          plugins: {legend: {display: true}},
+          scales: {y: {title: {display: true, text: 'Valore portafoglio (€)'}}}
+        }
+      });
+    } else {
+      this.chart.data.labels = labels;
+      this.chart.data.datasets = datasets;
+      this.chart.update();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `MonteCarloComponent`: input configurabili per anni e numero simulazioni
- Grafico Chart.js con 5 curve percentili (P5=rosso, P25=arancio, P50=blu, P75=verde, P95=viola)
- P50 (mediana) con linea più spessa come riferimento principale
- Nota esplicativa legenda sotto i controlli
- Nuovo tab 'Monte Carlo' nel MainComponent

## Test plan
- [ ] Aprire tab 'Monte Carlo' → form visibile, canvas vuoto
- [ ] Cliccare 'Esegui simulazione' → grafico con 5 curve appare
- [ ] Cambiare anni/simulazioni e rieseguire → grafico si aggiorna

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)