### PR TITLE
feat/fix: JWT auth + review fixes (dates, errors, env)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,7 +44,13 @@
                   "maximumError": "4kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
             },
             "development": {
               "optimization": false,

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,5 @@
-<app-main-component></app-main-component>
+<div class="app-toolbar" *ngIf="isLoggedIn()">
+  <span class="app-title">MoneyManage</span>
+  <button (click)="logout()">Logout</button>
+</div>
 <router-outlet></router-outlet>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,29 +1,18 @@
-import { TestBed } from '@angular/core/testing';
-import { AppComponent } from './app.component';
+import {TestBed} from '@angular/core/testing';
+import {provideRouter} from '@angular/router';
+import {provideHttpClient} from '@angular/common/http';
+import {AppComponent} from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [provideRouter([]), provideHttpClient()]
     }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
-  });
-
-  it(`should have the 'MoneyManageFrontend' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('MoneyManageFrontend');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, MoneyManageFrontend');
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,27 +1,28 @@
 import {Component} from '@angular/core';
-import {LineGraphComponent} from "./line-graph/line-graph.component";
-import {TransactionsTableComponent} from "./transactions-table/transactions-table.component";
-import {RouterOutlet} from "@angular/router";
-import {CommonModule, NgIf} from "@angular/common";
-import {MainComponentComponent} from "./main-component/main-component.component";
-import {MatTableModule} from "@angular/material/table";
+import {Router, RouterOutlet} from '@angular/router';
+import {NgIf} from '@angular/common';
+import {AuthService} from './auth/auth.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   standalone: true,
   imports: [
-    LineGraphComponent,
-    TransactionsTableComponent,
     RouterOutlet,
-    NgIf,
-    MainComponentComponent,
-    CommonModule,
-    MatTableModule // Import MatTableModule
-
+    NgIf
   ],
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
+  constructor(private auth: AuthService, private router: Router) {
+  }
 
+  isLoggedIn(): boolean {
+    return this.auth.isLoggedIn();
+  }
+
+  logout(): void {
+    this.auth.logout();
+    this.router.navigate(['/login']);
+  }
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,13 +1,15 @@
-import {ApplicationConfig, importProvidersFrom} from '@angular/core';
+import {ApplicationConfig} from '@angular/core';
 import {provideRouter} from '@angular/router';
 
 import {routes} from './app.routes';
-import {HttpClientModule} from "@angular/common/http";
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import {provideHttpClient, withInterceptors} from '@angular/common/http';
+import {provideAnimationsAsync} from '@angular/platform-browser/animations/async';
+import {authInterceptor} from './auth/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
-    importProvidersFrom(HttpClientModule), provideAnimationsAsync()
+    provideHttpClient(withInterceptors([authInterceptor])),
+    provideAnimationsAsync()
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,10 @@
-import { Routes } from '@angular/router';
+import {Routes} from '@angular/router';
+import {MainComponentComponent} from './main-component/main-component.component';
+import {LoginComponent} from './login/login.component';
+import {authGuard} from './auth/auth.guard';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {path: 'login', component: LoginComponent},
+  {path: '', component: MainComponentComponent, canActivate: [authGuard]},
+  {path: '**', redirectTo: ''}
+];

--- a/src/app/auth/auth.guard.ts
+++ b/src/app/auth/auth.guard.ts
@@ -1,0 +1,13 @@
+import {inject} from '@angular/core';
+import {CanActivateFn, Router} from '@angular/router';
+import {AuthService} from './auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isLoggedIn()) {
+    return true;
+  }
+  router.navigate(['/login']);
+  return false;
+};

--- a/src/app/auth/auth.interceptor.ts
+++ b/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,11 @@
+import {HttpInterceptorFn} from '@angular/common/http';
+import {inject} from '@angular/core';
+import {AuthService} from './auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = inject(AuthService).getToken();
+  if (token) {
+    req = req.clone({setHeaders: {Authorization: `Bearer ${token}`}});
+  }
+  return next(req);
+};

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,0 +1,42 @@
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Observable, tap} from 'rxjs';
+import {environment} from '../../environments/environment';
+
+interface AuthResponse {
+  token: string;
+}
+
+@Injectable({providedIn: 'root'})
+export class AuthService {
+  private readonly tokenKey = 'auth_token';
+
+  constructor(private http: HttpClient) {
+  }
+
+  login(username: string, password: string): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${environment.apiBaseUrl}/api/auth/login`, {username, password})
+      .pipe(tap(res => this.storeToken(res.token)));
+  }
+
+  register(username: string, password: string): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${environment.apiBaseUrl}/api/auth/register`, {username, password})
+      .pipe(tap(res => this.storeToken(res.token)));
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenKey);
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  isLoggedIn(): boolean {
+    return !!this.getToken();
+  }
+
+  private storeToken(token: string): void {
+    localStorage.setItem(this.tokenKey, token);
+  }
+}

--- a/src/app/login/login.component.css
+++ b/src/app/login/login.component.css
@@ -1,0 +1,37 @@
+.login-container {
+  max-width: 320px;
+  margin: 10vh auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.login-container form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-container input {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.actions button {
+  flex: 1;
+  padding: 0.5rem;
+  cursor: pointer;
+}
+
+.error {
+  color: #c0392b;
+  font-size: 0.9rem;
+}

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -1,0 +1,13 @@
+<div class="login-container">
+  <h2>MoneyManage</h2>
+  <form (ngSubmit)="login()">
+    <input name="username" placeholder="Username" [(ngModel)]="username" required autocomplete="username">
+    <input name="password" type="password" placeholder="Password" [(ngModel)]="password" required
+           autocomplete="current-password">
+    <div class="error" *ngIf="error">{{ error }}</div>
+    <div class="actions">
+      <button type="submit">Login</button>
+      <button type="button" (click)="register()">Registrati</button>
+    </div>
+  </form>
+</div>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,0 +1,37 @@
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {NgIf} from '@angular/common';
+import {Router} from '@angular/router';
+import {AuthService} from '../auth/auth.service';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [FormsModule, NgIf],
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css']
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+  error = '';
+
+  constructor(private auth: AuthService, private router: Router) {
+  }
+
+  login(): void {
+    this.error = '';
+    this.auth.login(this.username, this.password).subscribe({
+      next: () => this.router.navigate(['/']),
+      error: () => this.error = 'Login fallito: credenziali non valide'
+    });
+  }
+
+  register(): void {
+    this.error = '';
+    this.auth.register(this.username, this.password).subscribe({
+      next: () => this.router.navigate(['/']),
+      error: () => this.error = 'Registrazione fallita'
+    });
+  }
+}

--- a/src/app/main-component/main-component.component.ts
+++ b/src/app/main-component/main-component.component.ts
@@ -38,32 +38,60 @@ export class MainComponentComponent implements OnInit {
     this.getDataAndRenderComponents();
   }
 
+  private pad(value: number): string {
+    return value.toString().padStart(2, '0');
+  }
+
+  private startOfDay(date: Date): string {
+    return `${date.getFullYear()}-${this.pad(date.getMonth() + 1)}-${this.pad(date.getDate())} 00:00:00.000`;
+  }
+
+  private endOfDay(date: Date): string {
+    return `${date.getFullYear()}-${this.pad(date.getMonth() + 1)}-${this.pad(date.getDate())} 23:59:59.999`;
+  }
+
   getDataAndRenderComponents() {
-    const fromTimestamp = '2024-02-01 00:00:00.000';
-    const toTimestamp = '2024-03-20 23:59:59.999';
+    const today = new Date();
+    const from = new Date(today);
+    from.setMonth(from.getMonth() - 6);
+
+    const fromTimestamp = this.startOfDay(from);
+    const toTimestamp = this.endOfDay(today);
     const apiUrlPrefix = 'http://localhost:8080/api/banks/transactions/';
     const graphDataApi = `${apiUrlPrefix}graph/${encodeURIComponent(fromTimestamp)}/${encodeURIComponent(toTimestamp)}`;
     const brokerGraph: string = "http://localhost:8080/api/brokers/transactions/worth/graph";
     const accountsListApi = `${apiUrlPrefix}accounts`;
 
-    this.http.get<GraphPointsDto>(graphDataApi).subscribe((data: GraphPointsDto) => {
-      this.graphPoints = data;
+    this.http.get<GraphPointsDto>(graphDataApi).subscribe({
+      next: (data: GraphPointsDto) => {
+        this.graphPoints = data;
+      },
+      error: (err) => console.error('Failed to load bank graph data', err)
     });
 
-    this.http.get<GraphPointsDto>(brokerGraph).subscribe((data: GraphPointsDto) => {
-      this.brokerGraph = data;
+    this.http.get<GraphPointsDto>(brokerGraph).subscribe({
+      next: (data: GraphPointsDto) => {
+        this.brokerGraph = data;
+      },
+      error: (err) => console.error('Failed to load broker graph data', err)
     });
 
-    this.http.get<string[]>(accountsListApi).subscribe((accountNames: string[]) => {
-      accountNames.forEach(accountName => {
-        const accountTableApi = `${apiUrlPrefix}table/${encodeURIComponent(fromTimestamp)}/${encodeURIComponent(toTimestamp)}?accountName=${accountName}`;
-        this.http.get<TransactionDto[]>(accountTableApi).subscribe((data: TransactionDto[]) => {
-          this.accountsData = {
-            ...this.accountsData,
-            [accountName]: data
-          };
+    this.http.get<string[]>(accountsListApi).subscribe({
+      next: (accountNames: string[]) => {
+        accountNames.forEach(accountName => {
+          const accountTableApi = `${apiUrlPrefix}table/${encodeURIComponent(fromTimestamp)}/${encodeURIComponent(toTimestamp)}?accountName=${accountName}`;
+          this.http.get<TransactionDto[]>(accountTableApi).subscribe({
+            next: (data: TransactionDto[]) => {
+              this.accountsData = {
+                ...this.accountsData,
+                [accountName]: data
+              };
+            },
+            error: (err) => console.error(`Failed to load transactions for ${accountName}`, err)
+          });
         });
-      });
-    })
+      },
+      error: (err) => console.error('Failed to load account list', err)
+    });
   }
 }

--- a/src/app/main-component/main-component.component.ts
+++ b/src/app/main-component/main-component.component.ts
@@ -8,6 +8,7 @@ import {GraphPointsDto} from "../../models/graph-points.dto";
 import {MatTableModule} from "@angular/material/table";
 import {MatTab, MatTabContent, MatTabGroup} from "@angular/material/tabs";
 import {LineGraph2Component} from "../broker-worth-graph/broker-worth-graph.component";
+import {environment} from "../../environments/environment";
 
 @Component({
   selector: 'app-main-component',
@@ -57,9 +58,9 @@ export class MainComponentComponent implements OnInit {
 
     const fromTimestamp = this.startOfDay(from);
     const toTimestamp = this.endOfDay(today);
-    const apiUrlPrefix = 'http://localhost:8080/api/banks/transactions/';
+    const apiUrlPrefix = `${environment.apiBaseUrl}/api/banks/transactions/`;
     const graphDataApi = `${apiUrlPrefix}graph/${encodeURIComponent(fromTimestamp)}/${encodeURIComponent(toTimestamp)}`;
-    const brokerGraph: string = "http://localhost:8080/api/brokers/transactions/worth/graph";
+    const brokerGraph: string = `${environment.apiBaseUrl}/api/brokers/transactions/worth/graph`;
     const accountsListApi = `${apiUrlPrefix}accounts`;
 
     this.http.get<GraphPointsDto>(graphDataApi).subscribe({

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,6 @@
+export const environment = {
+  production: true,
+  // Same-origin in production: the API is expected to be served behind the
+  // same host/reverse proxy as the frontend. Override for other setups.
+  apiBaseUrl: ''
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:8080'
+};


### PR DESCRIPTION
## Summary
Raccoglie le correzioni dalla code review e l'autenticazione JWT lato frontend (richiesta esplicita).

### Autenticazione (JWT)
- `AuthService`: login/register, token salvato in `localStorage`
- Interceptor funzionale che allega `Authorization: Bearer <token>`
- `authGuard` protegge la dashboard, redirect a `/login`
- `LoginComponent` (login + registrazione)
- Routing: `/login` pubblica, `/` (dashboard) protetta; shell con logout
- `app.config` passa a `provideHttpClient(withInterceptors([...]))`

### Fix dalla review
- Date hardcodate `2024-02/03` → finestra mobile ultimi 6 mesi calcolata a runtime
- Error handler su ogni `subscribe()` (prima i fallimenti erano silenziosi)
- URL API `http://localhost:8080` → `environment.apiBaseUrl` (`environment.ts` / `environment.prod.ts` + `fileReplacements`)
- Sistemato `app.component.spec.ts` (test di default già rotto: titolo/h1 inesistenti)

## CI
Il repo frontend **non ha pipeline CI**: questi cambiamenti vanno verificati con `ng serve` / `ng build` / `ng test`.

## Note
Richiede la PR backend gemella (endpoint `/api/auth/*` + Spring Security).

## Test plan
- [ ] `/` senza login → redirect a `/login`
- [ ] Registrazione/login → redirect alla dashboard, dati caricati
- [ ] Chiamate API includono l'header `Authorization`
- [ ] Logout → torna a `/login`
- [ ] `ng build` (production) usa `environment.prod.ts`