### PR TITLE
feat: add setup wizard for initial configuration

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,7 @@
 <div class="app-toolbar" *ngIf="isLoggedIn()">
   <span class="app-title">MoneyManage</span>
+  <a routerLink="/" style="color: white; text-decoration: none;">Dashboard</a>
+  <a routerLink="/setup" style="color: white; text-decoration: none;">Setup</a>
   <button (click)="logout()">Logout</button>
 </div>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Router, RouterOutlet} from '@angular/router';
+import {Router, RouterLink, RouterOutlet} from '@angular/router';
 import {NgIf} from '@angular/common';
 import {AuthService} from './auth/auth.service';
 
@@ -9,6 +9,7 @@ import {AuthService} from './auth/auth.service';
   standalone: true,
   imports: [
     RouterOutlet,
+    RouterLink,
     NgIf
   ],
   styleUrls: ['./app.component.css']

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,10 +1,12 @@
 import {Routes} from '@angular/router';
 import {MainComponentComponent} from './main-component/main-component.component';
 import {LoginComponent} from './login/login.component';
+import {SetupWizardComponent} from './setup-wizard/setup-wizard.component';
 import {authGuard} from './auth/auth.guard';
 
 export const routes: Routes = [
   {path: 'login', component: LoginComponent},
   {path: '', component: MainComponentComponent, canActivate: [authGuard]},
+  {path: 'setup', component: SetupWizardComponent, canActivate: [authGuard]},
   {path: '**', redirectTo: ''}
 ];

--- a/src/app/setup-wizard/setup-wizard.component.css
+++ b/src/app/setup-wizard/setup-wizard.component.css
@@ -1,0 +1,35 @@
+.setup-container {
+  max-width: 600px;
+  margin: 40px auto;
+  padding: 0 16px;
+}
+
+.step-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 0;
+}
+
+.file-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.account-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.result {
+  color: green;
+  font-size: 0.9em;
+}

--- a/src/app/setup-wizard/setup-wizard.component.html
+++ b/src/app/setup-wizard/setup-wizard.component.html
@@ -1,0 +1,86 @@
+<div class="setup-container">
+  <h2>Setup iniziale</h2>
+
+  <mat-stepper orientation="vertical" linear="false">
+
+    <mat-step label="Carica transazioni bancarie">
+      <div class="step-content">
+        <mat-form-field>
+          <mat-label>Banca</mat-label>
+          <mat-select [(ngModel)]="bankName">
+            <mat-option value="Revolut">Revolut</mat-option>
+            <mat-option value="Degiro">Degiro</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <div class="file-row">
+          <label>File CSV</label>
+          <input type="file" accept=".csv" (change)="onBankFileChange($event)"/>
+        </div>
+
+        <div class="actions">
+          <button mat-raised-button color="primary" (click)="uploadBankCsv()" [disabled]="!bankFile || bankUploadLoading">
+            {{ bankUploadLoading ? 'Caricamento...' : 'Upload' }}
+          </button>
+          <button mat-button matStepperNext>Avanti</button>
+        </div>
+
+        <p *ngIf="bankUploadResult" class="result">{{ bankUploadResult }}</p>
+      </div>
+    </mat-step>
+
+    <mat-step label="Carica transazioni broker (Degiro)">
+      <div class="step-content">
+        <div class="file-row">
+          <label>File CSV</label>
+          <input type="file" accept=".csv" (change)="onBrokerFileChange($event)"/>
+        </div>
+
+        <div class="actions">
+          <button mat-button matStepperPrevious>Indietro</button>
+          <button mat-raised-button color="primary" (click)="uploadBrokerCsv()" [disabled]="!brokerFile || brokerUploadLoading">
+            {{ brokerUploadLoading ? 'Caricamento...' : 'Upload' }}
+          </button>
+          <button mat-button matStepperNext>Avanti</button>
+        </div>
+
+        <p *ngIf="brokerUploadResult" class="result">{{ brokerUploadResult }}</p>
+      </div>
+    </mat-step>
+
+    <mat-step label="Imposta saldi attuali">
+      <div class="step-content">
+        <p>Inserisci il saldo attuale per ogni conto per calcolare i valori cumulativi storici.</p>
+
+        <button mat-stroked-button (click)="loadAccounts()" style="margin-bottom: 16px">
+          Carica conti
+        </button>
+
+        <div *ngFor="let account of accounts" class="account-row">
+          <mat-form-field>
+            <mat-label>{{ account }}</mat-label>
+            <input matInput type="number" [(ngModel)]="accountBalances[account]" placeholder="Saldo attuale (€)"/>
+          </mat-form-field>
+          <span *ngIf="cumulativeResults[account]" class="result">{{ cumulativeResults[account] }}</span>
+        </div>
+
+        <div class="actions">
+          <button mat-button matStepperPrevious>Indietro</button>
+          <button mat-raised-button color="primary" (click)="computeAll()" [disabled]="accounts.length === 0 || cumulativeLoading">
+            {{ cumulativeLoading ? 'Elaborazione...' : 'Calcola' }}
+          </button>
+        </div>
+      </div>
+    </mat-step>
+
+    <mat-step label="Completato">
+      <div class="step-content">
+        <p>Setup completato. Puoi ora visualizzare il dashboard.</p>
+        <div class="actions">
+          <button mat-raised-button color="primary" routerLink="/">Vai al Dashboard</button>
+        </div>
+      </div>
+    </mat-step>
+
+  </mat-stepper>
+</div>

--- a/src/app/setup-wizard/setup-wizard.component.ts
+++ b/src/app/setup-wizard/setup-wizard.component.ts
@@ -1,0 +1,137 @@
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {MatStepperModule} from '@angular/material/stepper';
+import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatListModule} from '@angular/material/list';
+import {RouterLink} from '@angular/router';
+import {environment} from '../../environments/environment';
+
+@Component({
+  selector: 'app-setup-wizard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatStepperModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatListModule,
+    RouterLink
+  ],
+  templateUrl: './setup-wizard.component.html',
+  styleUrl: './setup-wizard.component.css'
+})
+export class SetupWizardComponent {
+  bankName: string = 'Revolut';
+  bankFile: File | null = null;
+  bankUploadResult: string = '';
+  bankUploadLoading = false;
+
+  brokerFile: File | null = null;
+  brokerUploadResult: string = '';
+  brokerUploadLoading = false;
+
+  accounts: string[] = [];
+  accountBalances: { [account: string]: string } = {};
+  cumulativeResults: { [account: string]: string } = {};
+  cumulativeLoading = false;
+
+  private api = environment.apiBaseUrl;
+
+  constructor(private http: HttpClient) {}
+
+  onBankFileChange(event: Event) {
+    const input = event.target as HTMLInputElement;
+    this.bankFile = input.files?.[0] ?? null;
+  }
+
+  uploadBankCsv() {
+    if (!this.bankFile) return;
+    this.bankUploadLoading = true;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const csv = e.target?.result as string;
+      this.http.post(`${this.api}/api/banks/transactions/${this.bankName}/upload`, csv, {
+        headers: new HttpHeaders({'Content-Type': 'text/csv'}),
+        responseType: 'text'
+      }).subscribe({
+        next: () => {
+          this.bankUploadResult = 'Upload completato con successo.';
+          this.bankUploadLoading = false;
+        },
+        error: (err) => {
+          this.bankUploadResult = `Errore: ${err.message}`;
+          this.bankUploadLoading = false;
+        }
+      });
+    };
+    reader.readAsText(this.bankFile);
+  }
+
+  onBrokerFileChange(event: Event) {
+    const input = event.target as HTMLInputElement;
+    this.brokerFile = input.files?.[0] ?? null;
+  }
+
+  uploadBrokerCsv() {
+    if (!this.brokerFile) return;
+    this.brokerUploadLoading = true;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const csv = e.target?.result as string;
+      this.http.post(`${this.api}/api/brokers/transactions/upload`, csv, {
+        headers: new HttpHeaders({'Content-Type': 'text/csv'}),
+        responseType: 'text'
+      }).subscribe({
+        next: () => {
+          this.brokerUploadResult = 'Upload completato con successo.';
+          this.brokerUploadLoading = false;
+        },
+        error: (err) => {
+          this.brokerUploadResult = `Errore: ${err.message}`;
+          this.brokerUploadLoading = false;
+        }
+      });
+    };
+    reader.readAsText(this.brokerFile);
+  }
+
+  loadAccounts() {
+    this.http.get<string[]>(`${this.api}/api/banks/transactions/accounts`).subscribe(accounts => {
+      this.accounts = accounts;
+      accounts.forEach(a => this.accountBalances[a] = '');
+    });
+  }
+
+  computeAll() {
+    this.cumulativeLoading = true;
+    let remaining = this.accounts.length;
+    this.accounts.forEach(account => {
+      const balance = this.accountBalances[account];
+      if (!balance) {
+        remaining--;
+        if (remaining === 0) this.cumulativeLoading = false;
+        return;
+      }
+      this.http.get(`${this.api}/api/banks/transactions/accounts/${account}/computeCumulativeAmount/${balance}`).subscribe({
+        next: () => {
+          this.cumulativeResults[account] = 'OK';
+          remaining--;
+          if (remaining === 0) this.cumulativeLoading = false;
+        },
+        error: (err) => {
+          this.cumulativeResults[account] = `Errore: ${err.message}`;
+          remaining--;
+          if (remaining === 0) this.cumulativeLoading = false;
+        }
+      });
+    });
+  }
+}


### PR DESCRIPTION
Replaces #6 (rebased on prod after JWT auth merge).

- `SetupWizardComponent`: 4-step Material Stepper (bank CSV, broker CSV, balances, done)
- Route `/setup` guarded by `authGuard`
- App shell gets Dashboard + Setup nav links
- Uses `environment.apiBaseUrl` instead of hardcoded `localhost:8080`

Closes #2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJQ26bPgm3BMSxePMsZsEe)_